### PR TITLE
Update 03_euler_lagrange_equation.tex

### DIFF
--- a/ib/vp/03_euler_lagrange_equation.tex
+++ b/ib/vp/03_euler_lagrange_equation.tex
@@ -174,7 +174,7 @@ Now, we have
 The two solutions correspond to the two directions in which we can trace the path.
 We then can arrive at
 \[
-	\pm \frac{1 - k^2}{k} \cos(\phi - \phi_0) = \cot \theta
+	\pm \frac{\sqrt{1 - k^2}}{k} \cos(\phi - \phi_0) = \cot \theta
 \]
 We will be able to see that this corresponds to a great circle; that is, the intersection of a plane through the origin with the sphere.
 We will show later that geodesics on a sphere are \textit{only} segments of a great circle.


### PR DESCRIPTION
There is an error in the final result for the geodesics on a sphere. We should get 
$$\pm\dfrac{\sqrt{1-k^2}}{k}\cos(\phi-\phi_0)=\cot\theta$$
by the integral; the file right now is missing the square root sign on the numerator.

For reference, I will attach my calculation below.

We have 
$$\phi=\pm\int\dfrac{kd\theta}{\sin\theta\sqrt{\sin^2\theta-k^2}}=\pm\int\dfrac{k(-\csc^2\theta d\theta)}{-\sin\theta\csc^2\theta\sqrt{\sin^2\theta-k^2}}=\pm\int\dfrac{k(-\csc^2\theta d\theta)}{-\sqrt{1-k^2\csc^2\theta}}=\pm\int\dfrac{k(-\csc^2\theta d\theta)}{-\sqrt{1-k^2-k^2\cot^2\theta}}$$
Substitute $u=\cot\theta$, $du=-\csc^2\theta d\theta$ to obtain
$$\phi=\pm\int\dfrac{-k du}{\sqrt{1-k^2-k^2u}}=\pm\int\dfrac{-du}{\sqrt{\frac{1-k^2}{k^2}-u^2}}=\arccos\left(\dfrac{k}{\sqrt{1-k^2}}u\right)+\phi_0$$
Rearranging,
$$\pm\dfrac{\sqrt{1-k^2}}{k}\cos(\phi-\phi_0)=\cot\theta$$