### PR TITLE
Update 04_extensions_to_the_euler_lagrange_equation.tex

### DIFF
--- a/ib/vp/04_extensions_to_the_euler_lagrange_equation.tex
+++ b/ib/vp/04_extensions_to_the_euler_lagrange_equation.tex
@@ -160,15 +160,15 @@ Evaluating the functional on this perturbed \( \phi \) gives
 	F[\phi + \varepsilon\eta] - F[\phi] = \varepsilon \iiint_{\mathcal D} \qty{ \eta \pdv{f}{\phi} + \eta_x \pdv{f}{\phi_x} + \eta_y \pdv{f}{\phi_y} + \eta_z \pdv{f}{\phi_z} } \dd{x}\dd{y}\dd{z} + O(\varepsilon^2)
 \]
 \[
-	= \varepsilon \iiint_{\mathcal D} \qty{ \eta \pdv{f}{\phi} + \underbrace{\div(\eta\qty(\pdv{f}{\phi_x}, \pdv{f}{\phi_y}, \pdv{f}{\phi_z}))}_{\mathclap{\text{apply divergence theorem since \( \eta \) vanishes on \( \partial \mathcal D \)}}} - \eta \div(\pdv{f}{\phi_x}, \pdv{f}{\phi_y}, \pdv{f}{\phi_z}) } \dd{x}\dd{y}\dd{z} + O(\varepsilon^2)
+	= \varepsilon \iiint_{\mathcal D} \qty{ \eta \pdv{f}{\phi} + \underbrace{\nabla\cdot(\eta\qty(\pdv{f}{\phi_x}, \pdv{f}{\phi_y}, \pdv{f}{\phi_z}))}_{\mathclap{\text{apply divergence theorem since \( \eta \) vanishes on \( \partial \mathcal D \)}}} - \eta \nabla\cdot(\pdv{f}{\phi_x}, \pdv{f}{\phi_y}, \pdv{f}{\phi_z}) } \dd{x}\dd{y}\dd{z} + O(\varepsilon^2)
 \]
 \[
-	= \varepsilon \iiint_{\mathcal D} \eta \qty{ \pdv{f}{\phi} - \div(\pdv{f}{\phi_x}, \pdv{f}{\phi_y}, \pdv{f}{\phi_z}) } \dd{x}\dd{y}\dd{z} + O(\varepsilon^2)
+	= \varepsilon \iiint_{\mathcal D} \eta \qty{ \pdv{f}{\phi} - \nabla\cdot(\pdv{f}{\phi_x}, \pdv{f}{\phi_y}, \pdv{f}{\phi_z}) } \dd{x}\dd{y}\dd{z} + O(\varepsilon^2)
 \]
 % Doesn't fit on page if we are in an align environment.
 Now, we can apply the fundamental lemma to give the Euler--Lagrange equation for multiple independent variables.
 \[
-	\pdv{f}{\phi} - \div(\pdv{f}{\phi_x},\pdv{f}{\phi_y},\pdv{f}{\phi_z}) = 0
+	\pdv{f}{\phi} - \nabla\cdot(\pdv{f}{\phi_x},\pdv{f}{\phi_y},\pdv{f}{\phi_z}) = 0
 \]
 Or, in suffix notation (with the summation convention),
 \[


### PR DESCRIPTION
Fixing the notation for divergence. \div is rendered as $\div$. I changed it to $\nabla\cdot$