### PR TITLE
Update 01_fourier_series.tex

### DIFF
--- a/ib/methods/01_fourier_series.tex
+++ b/ib/methods/01_fourier_series.tex
@@ -199,7 +199,7 @@ Parseval's theorem relates the integral of the square of a function with the squ
 	Suppose \( f \) has Fourier coefficients \( a_i, b_i \).
 	Then
 	\begin{align*}
-		\int_0^{2L} [f(x)]^2 \dd{x} & = \int_0^2L \qty[ \frac{1}{2}a_0 + \sum_{n=1}^\infty a_k \cos \frac{k \pi x}{L} + \sum_{n=1}^\infty b_n \sin \frac{n\pi x}{L} ]^2 \dd{x}           \\
+		\int_0^{2L} [f(x)]^2 \dd{x} & = \int_0^{2L} \qty[ \frac{1}{2}a_0 + \sum_{n=1}^\infty a_k \cos \frac{k \pi x}{L} + \sum_{n=1}^\infty b_n \sin \frac{n\pi x}{L} ]^2 \dd{x}           \\
 		\intertext{We can remove cross terms, since the basis functions are orthogonal.}
 		                            & = \int_0^{2L} \qty[ \frac{1}{4} a_0^2 + \sum_{n=1}^\infty a_n^2 \cos^2 \frac{n\pi x}{L} + \sum_{n=1}^\infty b_n^2 \sin^2 \frac{n\pi x}{L} ] \dd{x} \\
 		                            & = L \qty[ \frac{1}{2} a_0^2 + \sum_{n=1}^\infty (a_n^2 + b_n^2) ]


### PR DESCRIPTION
Fixed the upper bound of the integral in Parseval's theorem.

![image](https://github.com/zeramorphic/cambridge-maths-notes/assets/73973586/d04ca838-43b9-4fa1-944d-f62d8f0365db)
