### PR TITLE
Update 02_elementary_properties.tex

### DIFF
--- a/ib/markov/02_elementary_properties.tex
+++ b/ib/markov/02_elementary_properties.tex
@@ -279,7 +279,7 @@ Recall that
 \begin{theorem}
 	The vector \( (k_i^A)_{i \in I} \) is the minimal non-negative solution to the system of equations
 	\[
-		\begin{cases}
+		k_i^A = \begin{cases}
 			0                                   & \text{if } i \in A     \\
 			1 + \sum_{j \not\in A} P(i,j) k_j^A & \text{if } i \not\in A
 		\end{cases}


### PR DESCRIPTION
Apparently $k_i^A$ was missing.
![image](https://github.com/zeramorphic/cambridge-maths-notes/assets/73973586/5a3c37f9-baa7-4c26-9c72-5db5c47411f1)
